### PR TITLE
Use cache on CI for `node_modules`

### DIFF
--- a/.github/workflows/SteamBadgesDB-ci.yml
+++ b/.github/workflows/SteamBadgesDB-ci.yml
@@ -27,6 +27,17 @@ jobs:
       run: node --version
     - name: Verify NPM
       run: npm --version
+      
+    - name: Cache Node Modules
+      id: node-cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: node-modules-${{ hashFiles('package-lock.json') }}
         
-    - name: Build & Test (${{ matrix.os }})
-      run: npm ci && npm test
+    - name: Install NPM Dependencies
+      if: steps.node-cache.outputs.cache-hit != 'true'
+      run: npm ci
+      
+    - name: Run Tests (${{ matrix.os }})
+      run: npm test

--- a/.github/workflows/SteamBadgesDB-ci.yml
+++ b/.github/workflows/SteamBadgesDB-ci.yml
@@ -29,14 +29,15 @@ jobs:
       run: npm --version
       
     - name: Cache Node Modules
-      id: node-cache
-      uses: actions/cache@v2
+      id: cache
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: node-modules-${{ hashFiles('package-lock.json') }}
+        enableCrossOsArchive: true
         
     - name: Install NPM Dependencies
-      if: steps.node-cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: npm ci
       
     - name: Run Tests (${{ matrix.os }})

--- a/.github/workflows/SteamBadgesDB-self-update.yml
+++ b/.github/workflows/SteamBadgesDB-self-update.yml
@@ -23,7 +23,16 @@ jobs:
         - name: Verify NPM
           run: npm --version
 
-        - name: Download Dependencies
+        - name: Cache Node Modules
+          id: cache
+          uses: actions/cache@v3
+          with:
+            path: node_modules
+            key: node-modules-${{ hashFiles('package-lock.json') }}
+            enableCrossOsArchive: true
+
+        - name: Install NPM Dependencies
+          if: steps.cache.outputs.cache-hit != 'true'
           run: npm ci
 
         - name: Run SteamCardExchange Scrapper


### PR DESCRIPTION
Currently, we are not using any cache during CI.. this can cause longer builds.
Use approach shown at https://www.jonathan-wilkinson.com/github-actions-cache-everything as an improvement for current workflows.