### PR TITLE
ci: ensure node.js 21 support

### DIFF
--- a/.github/workflows/SteamBadgesDB-ci.yml
+++ b/.github/workflows/SteamBadgesDB-ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [18, 20]
+        node: [18, 20, 21]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5


### PR DESCRIPTION
### Node.js 21 is now available!

Node.js 21 will replace Node.js 20 as ‘Current’ release line when Node.js 20 enters long-term support (LTS) later this month. As per the release schedule, Node.js 21 will be ‘Current' release for the next 6 months, until April 2024 so we want to make sure steam-badges-db code works fine with this new node engine.

See https://nodejs.org/en/blog/announcements/v21-release-announce