### PR TITLE
Ensure CI also builds against Node.js 22

### DIFF
--- a/.github/workflows/SteamBadgesDB-ci.yml
+++ b/.github/workflows/SteamBadgesDB-ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [18, 20, 21]
+        node: [18, 20, 21, 22]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/.github/workflows/SteamBadgesDB-ci.yml
+++ b/.github/workflows/SteamBadgesDB-ci.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
+        check-latest: true
         
     - name: Verify Node.js Version
       run: node --version


### PR DESCRIPTION
Yay! Node.js 22 is now available!
Official release can be found at https://nodejs.org/en/blog/announcements/v22-release-announce